### PR TITLE
Fix timer initialization bug

### DIFF
--- a/Timer.cpp
+++ b/Timer.cpp
@@ -15,10 +15,13 @@ CGameTimer::CGameTimer()
 	m_nPausedPerformanceCounter = 0;
 	m_nStopPerformanceCounter = 0;
 
-	m_nSampleCount = 0;
-	m_nCurrentFrameRate = 0;
-	m_FramePerSecond = 0;
-	m_fFPSTimeElapsed = 0.0f;
+        m_nSampleCount = 0;
+        m_nCurrentFrameRate = 0;
+        m_FramePerSecond = 0;
+        m_fFPSTimeElapsed = 0.0f;
+
+        m_fTimeElapsed = 0.0f;
+        m_bStopped = false;
 }
 
 CGameTimer::~CGameTimer()

--- a/Timer.h
+++ b/Timer.h
@@ -22,7 +22,7 @@ public:
 
 private:
 	double							m_fTimeScale;						
-	float							m_fTimeElapsed;		
+	float							m_fTimeElapsed = 0.0f;		
 
 	__int64							m_nBasePerformanceCounter;
 	__int64							m_nPausedPerformanceCounter;
@@ -39,5 +39,5 @@ private:
 	unsigned long					m_FramePerSecond;					
 	float							m_fFPSTimeElapsed;		
 
-	bool							m_bStopped;
+	bool							m_bStopped = false;
 };


### PR DESCRIPTION
## Summary
- initialize `CGameTimer` members that were previously left uninitialized

## Testing
- `# no tests to run`


------
https://chatgpt.com/codex/tasks/task_e_6845220359448332accb9437bb6348f8