### PR TITLE
Add player shielding feature

### DIFF
--- a/GameFramework.h
+++ b/GameFramework.h
@@ -55,6 +55,9 @@ public:
 	void OnProcessingKeyboardMessage(HWND hWnd, UINT nMessageID, WPARAM wParam, LPARAM lParam);
 	LRESULT CALLBACK OnProcessingWindowMessage(HWND hWnd, UINT nMessageID, WPARAM wParam, LPARAM lParam);
 
-	void SetActive(bool bActive) { m_bActive = bActive; }
+        void SetActive(bool bActive) { m_bActive = bActive; }
+        bool IsShieldActive() const { return m_bShield; }
 };
+
+extern CGameFramework gGameFramework;
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "Player.h"
+#include "GameFramework.h"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -169,9 +170,25 @@ void CAirplanePlayer::OnUpdateTransform()
 
 void CAirplanePlayer::Render(HDC hDCFrameBuffer, CCamera* pCamera)
 {
-	CPlayer::Render(hDCFrameBuffer, pCamera);
+        CPlayer::Render(hDCFrameBuffer, pCamera);
 
-	for (int i = 0; i < BULLETS; i++) if (m_ppBullets[i]->m_bActive) m_ppBullets[i]->Render(hDCFrameBuffer, pCamera);
+        for (int i = 0; i < BULLETS; i++) if (m_ppBullets[i]->m_bActive) m_ppBullets[i]->Render(hDCFrameBuffer, pCamera);
+
+        if (gGameFramework.IsShieldActive())
+        {
+                CGraphicsPipeline::SetWorldTransform(&m_xmf4x4World);
+                XMFLOAT3 xmf3Screen = CGraphicsPipeline::Project(XMFLOAT3(0.0f, 0.0f, 0.0f));
+                xmf3Screen = CGraphicsPipeline::ScreenTransform(xmf3Screen);
+
+                int nRadius = 20;
+                HPEN hPen = ::CreatePen(PS_SOLID, 2, RGB(0, 255, 255));
+                HBRUSH hOldBrush = (HBRUSH)::SelectObject(hDCFrameBuffer, ::GetStockObject(NULL_BRUSH));
+                HPEN hOldPen = (HPEN)::SelectObject(hDCFrameBuffer, hPen);
+                ::Ellipse(hDCFrameBuffer, (int)(xmf3Screen.x - nRadius), (int)(xmf3Screen.y - nRadius), (int)(xmf3Screen.x + nRadius), (int)(xmf3Screen.y + nRadius));
+                ::SelectObject(hDCFrameBuffer, hOldPen);
+                ::SelectObject(hDCFrameBuffer, hOldBrush);
+                ::DeleteObject(hPen);
+        }
 }
 
 void CAirplanePlayer::FireBullet(CGameObject* pLockedObject)

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "Scene.h"
 #include "GraphicsPipeline.h"
+#include "GameFramework.h"
 
 CScene::CScene(CPlayer* pPlayer)
 {
@@ -308,6 +309,7 @@ void CScene::CheckPlayerByWallCollision()
 void CScene::CheckObjectByBulletCollisions()
 {
 	CBulletObject** ppBullets = ((CAirplanePlayer*)m_pPlayer)->m_ppBullets;
+    if (gGameFramework.IsShieldActive()) return;
 	for (int i = 0; i < m_nObjects; i++)
 	{
 		for (int j = 0; j < BULLETS; j++)
@@ -324,7 +326,7 @@ void CScene::CheckObjectByBulletCollisions()
 
 void CScene::Animate(float fElapsedTime)
 {
-	if (m_pWallsObject) // ? nullÀÏ ¶§ È£Ãâ ¹æÁö
+	if (m_pWallsObject) // ? nullÃ€Ã Â¶Â§ ÃˆÂ£ÃƒÃ¢ Â¹Ã¦ÃÃ¶
 		m_pWallsObject->Animate(fElapsedTime);
 
 	if (m_ppObjects)


### PR DESCRIPTION
## Summary
- expose shield status via new `IsShieldActive()` accessor
- allow other modules to reference the game framework instance
- draw a cyan ring around the player when shield is active
- ignore bullet collisions with objects while shielded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845990499948332b91f5f433ff83feb