### PR TITLE
Add roller coaster track and menu return

### DIFF
--- a/GameFramework.cpp
+++ b/GameFramework.cpp
@@ -131,9 +131,10 @@ void CGameFramework::OnProcessingKeyboardMessage(HWND hWnd, UINT nMessageID, WPA
 	case WM_KEYDOWN:
 		switch (wParam)
 		{
-		case VK_ESCAPE:
-			::PostQuitMessage(0);
-			break;
+                case VK_ESCAPE:
+                        if (dynamic_cast<CSceneMenu*>(m_pScene) != nullptr)
+                                ::PostQuitMessage(0);
+                        break;
 		case VK_RETURN:
 			break;
 		case VK_CONTROL:

--- a/Mesh.cpp
+++ b/Mesh.cpp
@@ -473,3 +473,50 @@ void CAxisMesh::Render(HDC hDCFrameBuffer)
 	::SelectObject(hDCFrameBuffer, hOldPen);
 	::DeleteObject(hPen);
 }
+
+CRollerCoasterMesh::CRollerCoasterMesh(XMFLOAT3* pPathPoints, int nPoints, float fWidth)
+        : CMesh(((nPoints - 1) * 2) + nPoints)
+{
+        float fHalfWidth = fWidth * 0.5f;
+        int k = 0;
+
+        for (int i = 0; i < nPoints - 1; i++)
+        {
+                CPolygon* pLeft = new CPolygon(2);
+                pLeft->SetVertex(0, CVertex(pPathPoints[i].x - fHalfWidth, pPathPoints[i].y, pPathPoints[i].z));
+                pLeft->SetVertex(1, CVertex(pPathPoints[i + 1].x - fHalfWidth, pPathPoints[i + 1].y, pPathPoints[i + 1].z));
+                SetPolygon(k++, pLeft);
+        }
+
+        for (int i = 0; i < nPoints - 1; i++)
+        {
+                CPolygon* pRight = new CPolygon(2);
+                pRight->SetVertex(0, CVertex(pPathPoints[i].x + fHalfWidth, pPathPoints[i].y, pPathPoints[i].z));
+                pRight->SetVertex(1, CVertex(pPathPoints[i + 1].x + fHalfWidth, pPathPoints[i + 1].y, pPathPoints[i + 1].z));
+                SetPolygon(k++, pRight);
+        }
+
+        for (int i = 0; i < nPoints; i++)
+        {
+                CPolygon* pCross = new CPolygon(2);
+                pCross->SetVertex(0, CVertex(pPathPoints[i].x - fHalfWidth, pPathPoints[i].y, pPathPoints[i].z));
+                pCross->SetVertex(1, CVertex(pPathPoints[i].x + fHalfWidth, pPathPoints[i].y, pPathPoints[i].z));
+                SetPolygon(k++, pCross);
+        }
+
+        XMFLOAT3 vMin = pPathPoints[0];
+        XMFLOAT3 vMax = pPathPoints[0];
+        for (int i = 1; i < nPoints; i++)
+        {
+                if (pPathPoints[i].x < vMin.x) vMin.x = pPathPoints[i].x;
+                if (pPathPoints[i].y < vMin.y) vMin.y = pPathPoints[i].y;
+                if (pPathPoints[i].z < vMin.z) vMin.z = pPathPoints[i].z;
+                if (pPathPoints[i].x > vMax.x) vMax.x = pPathPoints[i].x;
+                if (pPathPoints[i].y > vMax.y) vMax.y = pPathPoints[i].y;
+                if (pPathPoints[i].z > vMax.z) vMax.z = pPathPoints[i].z;
+        }
+        vMin.x -= fHalfWidth; vMax.x += fHalfWidth;
+        XMFLOAT3 center((vMin.x + vMax.x) * 0.5f, (vMin.y + vMax.y) * 0.5f, (vMin.z + vMax.z) * 0.5f);
+        XMFLOAT3 extents((vMax.x - vMin.x) * 0.5f, (vMax.y - vMin.y) * 0.5f, (vMax.z - vMin.z) * 0.5f);
+        m_xmOOBB = BoundingOrientedBox(center, extents, XMFLOAT4(0.0f, 0.0f, 0.0f, 1.0f));
+}

--- a/Mesh.h
+++ b/Mesh.h
@@ -81,8 +81,15 @@ public:
 class CAxisMesh : public CMesh
 {
 public:
-	CAxisMesh(float fWidth = 4.0f, float fHeight = 4.0f, float fDepth = 4.0f);
-	virtual ~CAxisMesh() { }
+        CAxisMesh(float fWidth = 4.0f, float fHeight = 4.0f, float fDepth = 4.0f);
+        virtual ~CAxisMesh() { }
 
-	virtual void Render(HDC hDCFrameBuffer);
+        virtual void Render(HDC hDCFrameBuffer);
+};
+
+class CRollerCoasterMesh : public CMesh
+{
+public:
+        CRollerCoasterMesh(XMFLOAT3* pPathPoints, int nPoints, float fWidth = 4.0f);
+        virtual ~CRollerCoasterMesh() { }
 };

--- a/SceneStage1.h
+++ b/SceneStage1.h
@@ -18,6 +18,14 @@ public:
 
 private:
     CAirplanePlayer* m_pAirplane = nullptr;
+    CGameObject* m_pTrack = nullptr;
+
+    static const int TRACK_POINTS = 12;
+    XMFLOAT3 m_xmf3Track[TRACK_POINTS];
+    float m_fSegmentLengths[TRACK_POINTS - 1];
+    int m_nCurrentSegment = 0;
+    float m_fSegmentPosition = 0.0f;
+    float m_fTrackSpeed = 20.0f;
     bool m_bFinished = false;
     bool m_bBackToMenu = false;
 };


### PR DESCRIPTION
## Summary
- design `CRollerCoasterMesh` to draw a simple roller‑coaster track
- add track creation and path-following logic to `CSceneStage1`
- update game framework to only exit on `Esc` in the menu

## Testing
- `g++ -std=c++11 -c Mesh.cpp SceneStage1.cpp GameFramework.cpp` *(fails: windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68452d0109b88332ae1c1109aa4f7b4b